### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_from_activity(activity_name: str, email: str):
+    """Remove a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Practice teamwork, fitness, and competitive soccer",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Develop basketball skills and play interschool matches",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Explore acting, stage performance, and theater production",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["mia@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Practice drawing, painting, and mixed-media art projects",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Robotics Club": {
+        "description": "Design, build, and program robots for competitions",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["ethan@mergington.edu", "james@mergington.edu"]
+    },
+    "Debate Society": {
+        "description": "Build critical thinking and public speaking through debates",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["lucas@mergington.edu", "evelyn@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsList = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${participant}</span>
+                    <button
+                      type="button"
+                      class="participant-delete"
+                      data-activity="${encodeURIComponent(name)}"
+                      data-email="${encodeURIComponent(participant)}"
+                      aria-label="Unregister ${participant}"
+                      title="Unregister participant"
+                    >
+                      🗑️
+                    </button>
+                  </li>
+                `
+              )
+              .join("")
+          : "<li class=\"no-participants\">No participants yet</li>";
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants:</strong></p>
+            <ul class="participants-list">
+              ${participantsList}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +90,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +107,44 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".participant-delete");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = decodeURIComponent(deleteButton.dataset.activity || "");
+    const email = decodeURIComponent(deleteButton.dataset.email || "");
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Failed to unregister participant";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,64 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding: 10px;
+  border-radius: 4px;
+  background-color: #eef3ff;
+  border: 1px solid #d6e1ff;
+}
+
+.participants-title {
+  margin-bottom: 6px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin-left: 0;
+  list-style: none;
+  color: #333;
+}
+
+.participant-item {
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background-color: #ffffff;
+  border: 1px solid #d8e3ff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.participant-item:last-child {
+  margin-bottom: 0;
+}
+
+.participant-email {
+  word-break: break-word;
+}
+
+.participant-delete {
+  background: transparent;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.participant-delete:hover {
+  background-color: #ffe8e8;
+}
+
+.no-participants {
+  font-style: italic;
+  color: #607d8b;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_activities = deepcopy(activities)
+    yield
+    activities.clear()
+    activities.update(original_activities)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,154 @@
+from src.app import activities
+
+
+def test_root_redirects_to_static_index(client):
+    # Arrange
+
+    # Act
+    response = client.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code in (307, 302)
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_static_index_is_served(client):
+    # Arrange
+
+    # Act
+    response = client.get("/static/index.html")
+
+    # Assert
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+def test_get_activities_returns_expected_schema(client):
+    # Arrange
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, dict)
+    assert "Chess Club" in payload
+
+    chess_club = payload["Chess Club"]
+    assert set(chess_club.keys()) == {
+        "description",
+        "schedule",
+        "max_participants",
+        "participants",
+    }
+
+
+def test_signup_success_adds_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "newstudent@mergington.edu"
+    assert email not in activities[activity_name]["participants"]
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+    assert email in activities[activity_name]["participants"]
+
+
+def test_signup_returns_404_for_unknown_activity(client):
+    # Arrange
+
+    # Act
+    response = client.post("/activities/Unknown Activity/signup", params={"email": "x@mergington.edu"})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_returns_400_for_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = activities[activity_name]["participants"][0]
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": existing_email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up"
+
+
+def test_signup_returns_422_when_email_missing(client):
+    # Arrange
+
+    # Act
+    response = client.post("/activities/Chess Club/signup")
+
+    # Assert
+    assert response.status_code == 422
+
+
+def test_signup_supports_activity_names_with_spaces(client):
+    # Arrange
+    activity_name = "Programming Class"
+    email = "spacecase@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert email in activities[activity_name]["participants"]
+
+
+def test_unregister_success_removes_participant(client):
+    # Arrange
+    activity_name = "Drama Club"
+    email = activities[activity_name]["participants"][0]
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/participants", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Unregistered {email} from {activity_name}"}
+    assert email not in activities[activity_name]["participants"]
+
+
+def test_unregister_returns_404_for_unknown_activity(client):
+    # Arrange
+
+    # Act
+    response = client.delete("/activities/Unknown Activity/participants", params={"email": "x@mergington.edu"})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_for_non_member(client):
+    # Arrange
+    activity_name = "Drama Club"
+    email = "not-in-club@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/participants", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Participant not found in this activity"
+
+
+def test_unregister_returns_422_when_email_missing(client):
+    # Arrange
+
+    # Act
+    response = client.delete("/activities/Drama Club/participants")
+
+    # Assert
+    assert response.status_code == 422


### PR DESCRIPTION
This pull request introduces several new features and improvements to the activities management app, focusing on participant management, user interface enhancements, and comprehensive testing. The main updates include the ability to unregister participants from activities, improved frontend display and interaction for participant lists, and the addition of robust backend and frontend tests to ensure reliability.

**Backend: Participant management and API enhancements**
- Added a new endpoint (`DELETE /activities/{activity_name}/participants`) to allow unregistering a participant from an activity, including validation for unknown activities and non-members. Also, the signup logic now prevents duplicate signups by checking if the student is already registered.
- Expanded the set of available activities with new entries such as "Soccer Team", "Basketball Team", "Drama Club", "Art Studio", "Robotics Club", and "Debate Society".

**Frontend: UI improvements for participant management**
- Enhanced the activities list to display participants for each activity, including a delete (unregister) button next to each participant. The UI updates automatically when participants are added or removed. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R15-R55) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R113-R150) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R93)
- Improved the visual styling for participant lists and participant management controls, making them more user-friendly and visually distinct.

**Testing: Backend and state management**
- Added a comprehensive test suite for the activities API, covering signup, unregister, error cases, and static file serving.
- Introduced a pytest fixture to ensure the `activities` state is reset between tests, preventing test interference and ensuring test reliability.